### PR TITLE
Using last queried time to space out queries

### DIFF
--- a/app/model/crypto-pair.js
+++ b/app/model/crypto-pair.js
@@ -14,6 +14,7 @@ const cryptoPairSchema = new Schema({
 	volume: Number,
 	change: Number,
 	lastUpdated: Number,
+	lastQueried: Number,
 });
 
 /**
@@ -28,6 +29,7 @@ cryptoPairSchema.methods.customJSON = function() {
 	const json = this.toJSON();
 	delete json._id;
 	delete json.__v;
+	delete json.lastQueried;
 	return json;
 };
 
@@ -44,6 +46,7 @@ cryptoPairSchema.methods.upsert = function(callback) {
 	newData.volume = this.volume;
 	newData.change = this.change;
 	newData.lastUpdated = this.lastUpdated;
+	newData.lastQueried = this.lastQueried;
 	this.model('CryptoPair')
 		.findOneAndUpdate(query, newData, { upsert: true, new: true })
 		.exec((err, doc) => {

--- a/app/request-sender.js
+++ b/app/request-sender.js
@@ -28,8 +28,7 @@ class RequestSender {
 					debug('data received');
 					const crypto = new CryptoPair(res.data.ticker);
 					crypto.lastUpdated = res.data.timestamp;
-					const epochSecNow = Math.ceil(Date.now() / 1000);
-					crypto.lastQueried = epochSecNow;
+					crypto.lastQueried = util.epochSecNow();
 					crypto.upsert((err, doc) => {
 						if (callback) { callback(undefined, doc.customJSON()); }
 					});

--- a/app/request-sender.js
+++ b/app/request-sender.js
@@ -28,6 +28,8 @@ class RequestSender {
 					debug('data received');
 					const crypto = new CryptoPair(res.data.ticker);
 					crypto.lastUpdated = res.data.timestamp;
+					const epochSecNow = Math.ceil(Date.now() / 1000);
+					crypto.lastQueried = epochSecNow;
 					crypto.upsert((err, doc) => {
 						if (callback) { callback(undefined, doc.customJSON()); }
 					});

--- a/app/router/default-router.js
+++ b/app/router/default-router.js
@@ -23,8 +23,7 @@ class DefaultRouter {
 					if (result) {
 						res.json(result);
 					} else if (doc) {
-						const epochSecNow = Math.ceil(Date.now() / 1000);
-						doc.lastQueried = epochSecNow;
+						doc.lastQueried = util.epochSecNow();
 						doc.upsert((err, doc) => {
 							res.json(doc.customJSON());
 						});

--- a/app/router/default-router.js
+++ b/app/router/default-router.js
@@ -23,7 +23,11 @@ class DefaultRouter {
 					if (result) {
 						res.json(result);
 					} else if (doc) {
-						res.json(doc.customJSON());
+						const epochSecNow = Math.ceil(Date.now() / 1000);
+						doc.lastQueried = epochSecNow;
+						doc.upsert((err, doc) => {
+							res.json(doc.customJSON());
+						});
 					} else {
 						res.send({
 							error: err
@@ -31,7 +35,7 @@ class DefaultRouter {
 					}
 				});
 			} else {
-				debug('database stored info is up to date');
+				debug('using database stored info');
 				res.json(doc.customJSON());
 			}
 		});

--- a/app/util/util.js
+++ b/app/util/util.js
@@ -4,7 +4,7 @@ const api = config.get('api');
 
 const createDebug = require('debug');
 createDebug.formatters.t = (v) => {
-	return new Date(v * 1000).toLocaleTimeString();
+	return new Date(v * 1000).toLocaleString('en-GB');
 };
 
 module.exports.epochSecNow = function() {

--- a/app/util/util.js
+++ b/app/util/util.js
@@ -7,11 +7,15 @@ createDebug.formatters.t = (v) => {
 	return new Date(v * 1000).toLocaleTimeString();
 };
 
+module.exports.epochSecNow = function() {
+	return Math.ceil(Date.now() / 1000);
+};
+
 module.exports.shouldUpdateFromApi = function(doc) {
 	if (doc) {
 		const interval = config.get('expireInSec');
 		const querySpacing = config.get('querySpacingInSec');
-		const epochSecNow = Math.ceil(Date.now() / 1000);
+		const epochSecNow = this.epochSecNow();
 		const lastUpdated = doc.lastUpdated;
 		const lastQueried = doc.lastQueried;
 		debug('now: %t, last updated: %t, last queried: %t', epochSecNow, lastUpdated, lastQueried);

--- a/app/util/util.js
+++ b/app/util/util.js
@@ -10,10 +10,14 @@ createDebug.formatters.t = (v) => {
 module.exports.shouldUpdateFromApi = function(doc) {
 	if (doc) {
 		const interval = config.get('expireInSec');
+		const querySpacing = config.get('querySpacingInSec');
 		const epochSecNow = Math.ceil(Date.now() / 1000);
-		const lastUpdated = doc.customJSON().lastUpdated;
-		debug('now: %t, last updated: %t', epochSecNow, lastUpdated);
-		return epochSecNow - interval > lastUpdated;
+		const lastUpdated = doc.lastUpdated;
+		const lastQueried = doc.lastQueried;
+		debug('now: %t, last updated: %t, last queried: %t', epochSecNow, lastUpdated, lastQueried);
+		const shouldUpdate = epochSecNow - interval > lastUpdated && 
+			(lastQueried === undefined || epochSecNow - querySpacing > lastQueried);
+		return shouldUpdate;
 	}
 	return true;
 };

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
 	"port": 8080,
 	"expireInSec": 120,
+	"querySpacingInSec": 60,
 	"api": "https://api.cryptonator.com/api/ticker/",
 	"dbUrl": "mongodb://localhost:27017/production",
 	"corsOrigin": "*",

--- a/test/database_test.js
+++ b/test/database_test.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('crypto:db-test');
 const mongoose = require('mongoose');
 const config = require('config');
 const dbUrl = config.get('dbUrl');
@@ -10,12 +11,12 @@ const CryptoMock = require('./mock/crypto-mock');
 describe('Database integration tests', () => {
 	before((done) => {
 		mongoose.connect(dbUrl);
-		mongoose.connection.on('error', console.error.bind(console, 'Database Connection Error'));
+		mongoose.connection.on('error', debug.bind(debug, 'Database Connection Error'));
 		mongoose.connection.once('open', () => {
 			const c = new CryptoPair(CryptoMock.btc_usd);
 			CryptoPair.remove({}, (err) => {
 				c.save((err) => {
-					console.log('connected to and initialised DB: ' + dbUrl);
+					debug('connected to and initialised DB: ' + dbUrl);
 					done();
 				});
 			});
@@ -24,7 +25,7 @@ describe('Database integration tests', () => {
 
 	after((done) => {
 		mongoose.connection.close(() => {
-			console.log('closing connection to DB: ' + dbUrl);
+			debug('closing connection to DB: ' + dbUrl);
 			done();
 		});
 	});


### PR DESCRIPTION
- introduced last queried time in mongoose model
- util now checks last queried time too to decide if a http request is sent to third party API
- updated server / router / sender to consider last queried time saving
- updated tests for everything related
- replaced console logs in test with debug logs